### PR TITLE
Fix repaint after import and delete point

### DIFF
--- a/editgpx/src/org/openstreetmap/josm/plugins/editgpx/EditGpxMode.java
+++ b/editgpx/src/org/openstreetmap/josm/plugins/editgpx/EditGpxMode.java
@@ -101,7 +101,7 @@ public class EditGpxMode extends MapMode implements LayerChangeListener {
             }
         }
         oldRect = null;
-        MainApplication.getMap().mapView.repaint();
+        currentEditLayer.invalidate();
     }
 
     /**
@@ -175,7 +175,7 @@ public class EditGpxMode extends MapMode implements LayerChangeListener {
             MainApplication.getLayerManager().addLayer(currentEditLayer);
             currentEditLayer.initializeImport();
         }
-        MainApplication.getMap().mapView.repaint();
+        currentEditLayer.invalidate();
     }
 
     @Override

--- a/editgpx/src/org/openstreetmap/josm/plugins/editgpx/GPXLayerImportAction.java
+++ b/editgpx/src/org/openstreetmap/josm/plugins/editgpx/GPXLayerImportAction.java
@@ -102,7 +102,6 @@ class GPXLayerImportAction extends AbstractAction {
                     this.data.load(gpx.data);
                 }
             }
-            MainApplication.getMap().mapView.repaint();
 
         } else {
             // no gps layer


### PR DESCRIPTION
EditGpx plugin does not show yellow track points after import. Only after map drag or zoom. Similar happens after deleting track points: deleted track points do not disappear immediately, only after map drag or zoom.

This PR fixes these issues.