### PR TITLE
getIndex Error when negative degree location

### DIFF
--- a/ElevationProfile/src/org/openstreetmap/josm/plugins/elevation/HgtReader.java
+++ b/ElevationProfile/src/org/openstreetmap/josm/plugins/elevation/HgtReader.java
@@ -204,8 +204,8 @@ public class HgtReader {
         double lonDegrees = latLon.lon();
 
         float fraction = ((float) SRTM_EXTENT) / (mapSize - 1);
-        int latitude = (int) Math.round(frac(latDegrees) / fraction);
-        int longitude = (int) Math.round(frac(lonDegrees) / fraction);
+        int latitude = (int) Math.abs(Math.round(frac(latDegrees) / fraction));
+        int longitude = (int) Math.abs(Math.round(frac(lonDegrees) / fraction));
         if (latDegrees >= 0)
         {
             latitude = mapSize - latitude - 1;


### PR DESCRIPTION
The int variables "latitude" and "longitude" declared in this method should never be negative, and they could if the input parameter "latlon", has some negative coordinates. It ends throwing an arrayIndexOutOfBounds exceptions.

Tested correctly with the following coordinates:
// Alcoy, Alicante
testHgtData(38.698160, -0.481258, "N38W001.hgt", 541); 
//Morbihan, Francia
testHgtData(47.984655, -2.881880, "N47W003.hgt", 98); 
//Valencia
testHgtData(39.470022, -0.386717, "N39W001.hgt", 16); 
//Mulhacen
testHgtData(37.052407, -3.311801, "N37W004.hgt", 3452);